### PR TITLE
Fix bug which caused apps with no uri to fail

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -74,12 +74,14 @@ func (p *Plugin) Exec() error {
 	}
 
 	// Set every uri extract to true by default
-	var fetch []marathon.Fetch
-	for _, v := range *app.Fetch {
-		v.Extract = true
-		fetch = append(fetch, v)
+	if app.Fetch != nil {
+		var fetch []marathon.Fetch
+		for _, v := range *app.Fetch {
+			v.Extract = true
+			fetch = append(fetch, v)
+		}
+		app.Fetch = &fetch
 	}
-	app.Fetch = &fetch
 
 	app.Container.Docker.AddParameter("log-driver", "json-file")
 	app.Container.Docker.AddParameter("log-opt", "max-size=512m")

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -11,6 +11,22 @@ var app = `
 id: quintoandar/app
 cpus: 0.1
 mem: 128
+container:
+  type: DOCKER
+  docker: 
+    image: quintoandar/app
+    network: BRIDGE
+    portMappings:
+      - containerPort: 8080
+healthChecks:
+  - protocol: MESOS_HTTP
+    path: /health
+`
+
+var appWithURI = `
+id: quintoandar/app
+cpus: 0.1
+mem: 128
 fetch:
   - uri: "http://internal.lb.maintenance.marathon.mesos:10002/docker.tar.gz"
 container:
@@ -25,8 +41,15 @@ healthChecks:
     path: /health
 `
 
-func TestPlugin(t *testing.T) {
+func TestAppDeploy(t *testing.T) {
+	deploy(t, app)
+}
 
+func TestAppWithURIDeploy(t *testing.T) {
+	deploy(t, appWithURI)
+}
+
+func deploy(t *testing.T, app string) {
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {
 


### PR DESCRIPTION
Apps that didn't have the Fetch URI field would fail with a nil pointer exception. Add a check to see if the Fetch pointer is not null before setting "extract" to True.