### PR TITLE
Set deleteDeployment force to True

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -121,7 +121,7 @@ func (p *Plugin) Exec() error {
 				"timeout":    p.Timeout,
 			}).Info("rolling back")
 
-			rollback, err := client.DeleteDeployment(dep.DeploymentID, false)
+			rollback, err := client.DeleteDeployment(dep.DeploymentID, true)
 
 			if err != nil {
 				ctx.WithFields(log.Fields{


### PR DESCRIPTION
When deleteDeployment force is set to false, a new deployment will
be created to revert the current settings. However, this will a new
deployment, even though the running container has the same config
of the rollback.

Furthermore, it actually kills the running container, so there's
downtime.

By setting force=true, the deployment is canceled, but not new
deployment happens.