### PR TITLE
Patch go-marathon sdk to use 'force' on rollback

### DIFF
--- a/vendor/github.com/gambol99/go-marathon/deployment.go
+++ b/vendor/github.com/gambol99/go-marathon/deployment.go
@@ -108,7 +108,7 @@ func (r *marathonClient) Deployments() ([]*Deployment, error) {
 // 	force:	whether or not to force the deletion
 func (r *marathonClient) DeleteDeployment(id string, force bool) (*DeploymentID, error) {
 	deployment := new(DeploymentID)
-	err := r.apiDelete(fmt.Sprintf("%s/%s", marathonAPIDeployments, id), nil, deployment)
+	err := r.apiDelete(fmt.Sprintf("%s/%s?force=%t", marathonAPIDeployments, id, force), nil, deployment)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The SDK was ignore the force parameter on the DeleteDeployment operation. Add it as a querystring to the request.