### PR TITLE
Add better logs and update rollback

### DIFF
--- a/test_response.json
+++ b/test_response.json
@@ -1,0 +1,25 @@
+{
+  "app": {
+    "id": "quintoandar/app",
+    "cpus": 0.1,
+    "mem": 128,
+    "container": {
+      "type": "DOCKER",
+      "docker": {
+        "image": "quintoandar/app",
+        "network": "BRIDGE",
+        "portMappings": [
+          {
+            "containerPort": 8080
+          }
+        ]
+      }
+    },
+    "healthChecks": [
+      {
+        "protocol": "MESOS_HTTP",
+        "path": "/health"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Do a rollback when a deploy fails.

When a deploy fails, verify that all failed tasks have stopped before triggering a rollback. This will stop Marathon from killing the healthy containers before the new ones are up and will execute a proper rolling update. See more information about the limitations of Marathon rollback behavior here: https://github.com/mesosphere/marathon/issues/4046

Also override some default healthcheck configuration _if they are not set_. Marathon will give very large healthcheck timeout values (including a grace period of 5 minutes). This means it would take over 5 minutes for a unhealthy deployment to actually be killed, which might cause the deploy to time out _before_ the rollback is applied.